### PR TITLE
fix kafka test

### DIFF
--- a/bot/src/test/java/edu/java/bot/BotApplicationTest.java
+++ b/bot/src/test/java/edu/java/bot/BotApplicationTest.java
@@ -1,11 +1,8 @@
 package edu.java.bot;
 
 import com.pengrad.telegrambot.TelegramBot;
-import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
 
 @SpringBootTest
 public class BotApplicationTest {
@@ -13,8 +10,4 @@ public class BotApplicationTest {
     @MockBean
     private TelegramBot telegramBot;
 
-    @Test
-    private void enableSendingMessagesToChats() {
-        doNothing().when(telegramBot).execute(any());
-    }
 }

--- a/bot/src/test/java/edu/java/bot/kafka/KafkaIntegrationTest.java
+++ b/bot/src/test/java/edu/java/bot/kafka/KafkaIntegrationTest.java
@@ -1,6 +1,8 @@
 package edu.java.bot.kafka;
 
 import edu.java.bot.BotApplicationTest;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.KafkaContainer;
@@ -8,7 +10,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers
-public class KafkaIntegrationTest {
+public class KafkaIntegrationTest extends BotApplicationTest {
 
     public static KafkaContainer KAFKA;
 
@@ -24,6 +26,12 @@ public class KafkaIntegrationTest {
         registry.add("kafka.scrapper-topic", () -> "bot-test.scrapper-topic");
         registry.add("kafka.consumer-group", () -> "bot-test-group");
         registry.add("kafka.dlq-topic", () -> "bot-test.scrapper-topic_dlq");
+    }
+
+    @Test
+    @SneakyThrows
+    public void waitTelegramBotMock() {
+        Thread.sleep(1000);
     }
 
 }


### PR DESCRIPTION
Решил проблему провала первого теста из KafkaConsumerTest при наследовании BotApplicationTest с помощью задержки